### PR TITLE
INC-1335: Fix duplicated key

### DIFF
--- a/spec/schemas/incentives/prison-level-changed.yml
+++ b/spec/schemas/incentives/prison-level-changed.yml
@@ -22,7 +22,7 @@ payload:
           description: Incentive level code
           type: string
           example: "STD"
-        incentiveLevel:
+        prisonId:
           description: Prison ID
           type: string
           example: "MDI"


### PR DESCRIPTION
There was a problem in the YAML file for the
`incentives.prison-level.changed` domain event.

The `additionalInformation` had a duplicated key as I copied and pasted but did not rename to `prisonId`.

AsyncAPI Studio was complaining :)