### PR TITLE
MAP-1282 Add new schemas for prison location changes


### DIFF
--- a/spec/schemas/locations-inside-prison/location-inside-prison-amended.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-amended.yaml
@@ -1,0 +1,33 @@
+name: location.inside.prison.amended
+title: Locations – a location inside prison has been amended
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.amended
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "MDI-1-1-001 A location inside prison has been amended"
+    additionalInformation:
+      type: object
+      properties:
+        id:
+          description: Internal location identifier
+          type: string
+          format: uuid
+          example: 11111111-2222-3333-4444-555555555555
+        key:
+          description: Unique reference to the location
+          type: string
+          example: MDI-1-1-001
+        source:
+          description: Where the location was updated
+          enum: [DPS, NOMIS]
+          example: DPS

--- a/spec/schemas/locations-inside-prison/location-inside-prison-created.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-created.yaml
@@ -1,0 +1,33 @@
+name: location.inside.prison.created
+title: Locations – a location inside prison has been created
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.created
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "MDI-1-1-001 A location inside prison has been created"
+    additionalInformation:
+      type: object
+      properties:
+        id:
+          description: Internal location identifier
+          type: string
+          format: uuid
+          example: 11111111-2222-3333-4444-555555555555
+        key:
+          description: Unique reference to the location
+          type: string
+          example: MDI-1-1-001
+        source:
+          description: Where the location was created
+          enum: [DPS, NOMIS]
+          example: DPS

--- a/spec/schemas/locations-inside-prison/location-inside-prison-deactivated.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-deactivated.yaml
@@ -1,0 +1,33 @@
+name: location.inside.prison.deactivated
+title: Locations – a location inside prison has been de-activated
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.deactivated
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "MDI-1-1-001 A location inside prison has been deactivated"
+    additionalInformation:
+      type: object
+      properties:
+        id:
+          description: Internal location identifier
+          type: string
+          format: uuid
+          example: 11111111-2222-3333-4444-555555555555
+        key:
+          description: Unique reference to the location
+          type: string
+          example: MDI-1-1-001
+        source:
+          description: Where the location was updated
+          enum: [DPS, NOMIS]
+          example: DPS

--- a/spec/schemas/locations-inside-prison/location-inside-prison-deleted.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-deleted.yaml
@@ -1,0 +1,33 @@
+name: location.inside.prison.deleted
+title: Locations – a location inside prison has been deleted
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.deleted
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "MDI-1-1-001 A location inside prison has been deleted"
+    additionalInformation:
+      type: object
+      properties:
+        id:
+          description: Internal location identifier
+          type: string
+          format: uuid
+          example: 11111111-2222-3333-4444-555555555555
+        key:
+          description: Unique reference to the location
+          type: string
+          example: MDI-1-1-001
+        source:
+          description: Where the location was deleted
+          enum: [DPS, NOMIS]
+          example: DPS

--- a/spec/schemas/locations-inside-prison/location-inside-prison-reactivated.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-reactivated.yaml
@@ -1,0 +1,33 @@
+name: location.inside.prison.reactivated
+title: Locations – a location inside prison has been re-activated
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.reactivated
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "MDI-1-1-001 A location inside prison has been reactivated"
+    additionalInformation:
+      type: object
+      properties:
+        id:
+          description: Internal location identifier
+          type: string
+          format: uuid
+          example: 11111111-2222-3333-4444-555555555555
+        key:
+          description: Unique reference to the location
+          type: string
+          example: MDI-1-1-001
+        source:
+          description: Where the location was updated
+          enum: [DPS, NOMIS]
+          example: DPS

--- a/spec/schemas/locations-inside-prison/location-inside-prison-signed-op-cap-amended.yaml
+++ b/spec/schemas/locations-inside-prison/location-inside-prison-signed-op-cap-amended.yaml
@@ -1,0 +1,28 @@
+name: location.inside.prison.signed-op-cap.amended
+title: Locations – the signed operation capacity of the prison has changed
+contentType: application/json
+payload:
+  type: object
+  properties:
+    version:
+      const: "1.0"
+    eventType:
+      const: location.inside.prison.signed-op-cap-amended
+    occurredAt:
+      type: string
+      format: date-time
+      example: 2023-12-05T12:34:56+00:00
+    description:
+      type: string
+      example: "Signed Op-Cap changed for MDI to 786"
+    additionalInformation:
+      type: object
+      properties:
+        key:
+          description: Prison where change made
+          type: string
+          example: MDI
+        source:
+          description: The source of the change to signed op-cap
+          enum: [DPS]
+          example: DPS


### PR DESCRIPTION

Added new schema files to define the structure and properties of different events related to changes in prison locations. These changes include creating, deleting, deactivating, reactivating, amending a location, and changing the signed operation capacity. Each schema includes properties such as version, eventType, occurredAt, description, additional information, which include identifier, key, and source of action.